### PR TITLE
Fix dependencies for tapestry and commons-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<name>Tapestry REST example</name>
 	<description>Example project for the Tapestry REST support</description>
 	<properties>
-		<tapestry.version>5.8.0-SNAPSHOT</tapestry.version>
+		<tapestry.version>5.8.3</tapestry.version>
 		<jackson.version>2.13.0</jackson.version>
 		<servlet-api.version>3.1.0</servlet-api.version>
 	</properties>
@@ -50,7 +50,12 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>1.7.5</version>
-		</dependency>		
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.13.0</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -62,6 +67,11 @@
 					<source>1.8</source>
 					<target>1.8</target>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>3.3.1</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Upgrade to versions available in mvn central
Add maven-war-plugin to resolve
Exception java.lang.ExceptionInInitializerError: Cannot access defaults field of Properties [in thread "Worker-296: Building"]